### PR TITLE
Fix book.json

### DIFF
--- a/book.json
+++ b/book.json
@@ -4,6 +4,6 @@
     "description": "Webpack, a module bundler, solves a significant problem for web developers. It can be daunting to learn but once you grok it, life gets easier. Same goes for React, a JavaScript library for building UIs. SurviveJS - Webpack + React shows you how to build a little Kanban application using these technologies. During the process you will learn the basics and will be able to take the skills to your own projects.",
     "language": "en",
     "structure": {
-        "readme": "manuscript/00_introduction.md"
+        "readme": "manuscript/introduction.md"
     }
 }


### PR DESCRIPTION
Simple fix, otherwise the book won't compile:
``` bash
> gitbook pdf . ./book.pdf

info: loading book configuration....OK 
info: >> 0 plugins loaded 

No README file

npm ERR! Linux 3.13.0-37-generic
npm ERR! argv "node" "/usr/bin/npm" "start"
npm ERR! node v0.10.38
npm ERR! npm  v2.10.0
npm ERR! code ELIFECYCLE
npm ERR! survivejs-webpack@0.1.0 start: `gitbook pdf . ./book.pdf`
npm ERR! Exit status 1
```