### PR TITLE
You have to init the store somewhere for the example to work.

### DIFF
--- a/manuscript/06_react_and_flux.md
+++ b/manuscript/06_react_and_flux.md
@@ -395,7 +395,8 @@ export default persist(
   connect(App, NoteStore),
   storage,
   noteStorageName,
-  () => NoteStore.getState()
+  () => NoteStore.getState(),
+  NoteActions.init(storage.get(noteStorageName))
 );
 ```
 


### PR DESCRIPTION
It is better to pass `NoteActions` or `NoteActions.init` trigger `init` in `constructor` method, but then it would require more changes down the page.