### PR TITLE
fix compatibility problem for building on Windows

### DIFF
--- a/manuscript/06_react_and_flux.md
+++ b/manuscript/06_react_and_flux.md
@@ -541,9 +541,9 @@ export default class App extends React.Component {
         <button onClick={() => this.addItem()}>+</button>
         <AltContainer
           stores={[NoteStore]}
-          inject={{
+          inject={ {
             items: () => NoteStore.getState().notes || []
-          }}
+          } }
         >
           <Notes onEdit={(id, task) => this.itemEdited(id, task)} />
         </AltContainer>

--- a/manuscript/07_from_notes_to_kanban.md
+++ b/manuscript/07_from_notes_to_kanban.md
@@ -38,9 +38,9 @@ export default class App extends React.Component {
         <button onClick={this.addLane}>+</button>
         <AltContainer
           stores={[LaneStore]}
-          inject={{
+          inject={ {
             items: () => LaneStore.getState().lanes || [],
-          }}
+          } }
         >
           <Lanes />
         </AltContainer>
@@ -206,9 +206,9 @@ export default class Lane extends React.Component {
         </div>
         <AltContainer
           stores={[NoteStore]}
-          inject={{
+          inject={ {
             items: () => NoteStore.getState().notes || [],
-          }}
+          } }
         >
           <Notes onEdit={this.noteEdited} />
         </AltContainer>


### PR DESCRIPTION
Fixed 3 errors on Windows, by converting "inject {{ ... }}" => "inject { { ... } }", just as in AltContainer docs.

Fixed errors:

Template render error: (X:\git\webpack_react_my\manuscript\06_react_and_flux.md) [Line 545, Column 18]
  expected variable end (In file 'manuscript/06_react_and_flux.md')

Template render error: (X:\git\webpack_react_my\manuscript\07_from_notes_to_kanban.md) [Line 42, Column 18]
  expected variable end (In file 'manuscript/07_from_notes_to_kanban.md')

Template render error: (X:\git\webpack_react_my\manuscript\07_from_notes_to_kanban.md) [Line 42, Column 18]
  expected variable end (In file 'manuscript/07_from_notes_to_kanban.md')