### PR TITLE
Docs: Add OS X instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Feedback is welcome. You can provide it through [the issue tracker](https://gith
 
 ## Generating Ebooks
 
-It is possible to generate an ebook version through Calibre. Make sure you have it installed before trying the generation script. You can get it from [Calibre site](http://calibre-ebook.com/download) or alternatively you can use the package manager of your operating system (`Homebrew-cask` for Mac, `sudo apt-get install calibre calibre-bin` for Ubuntu). If you use Homebrew-cask, you may need to add the Calibre CLI to your PATH (e.g. `export PATH=$PATH://opt/homebrew-cask/Caskroom/calibre/2.31.0/calibre.app/Contents/MacOS`).
+It is possible to generate an ebook version through Calibre. Make sure you have it installed before trying the generation script. You can get it from [Calibre site](http://calibre-ebook.com/download) or alternatively you can use the package manager of your operating system (Homebrew-cask for Mac, `sudo apt-get install calibre calibre-bin` for Ubuntu). If you use Homebrew-cask, you may need to add the Calibre CLI to your PATH (e.g. `export PATH=$PATH://opt/homebrew-cask/Caskroom/calibre/2.31.0/calibre.app/Contents/MacOS`).
 
 To generate a pdf version of the book, hit `npm install` and `npm start`. After that you should have `./book.pdf`.
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Feedback is welcome. You can provide it through [the issue tracker](https://gith
 
 ## Generating Ebooks
 
-It is possible to generate an ebook version through Calibre. Make sure you have it installed before trying the generation script. You can get it from [Calibre site](http://calibre-ebook.com/download) or alternatively you can use the package manager of your operating system (`brew`, `sudo apt-get install calibre calibre-bin` for Ubuntu).
+It is possible to generate an ebook version through Calibre. Make sure you have it installed before trying the generation script. You can get it from [Calibre site](http://calibre-ebook.com/download) or alternatively you can use the package manager of your operating system (`Homebrew-cask` for Mac, `sudo apt-get install calibre calibre-bin` for Ubuntu). If you use Homebrew-cask, you may need to add the Calibre CLI to your PATH (e.g. `export PATH=$PATH://opt/homebrew-cask/Caskroom/calibre/2.31.0/calibre.app/Contents/MacOS`).
 
 To generate a pdf version of the book, hit `npm install` and `npm start`. After that you should have `./book.pdf`.
 


### PR DESCRIPTION
Add instructions for generating an ebook using OS X. Homebrew does not
contain a formula for Calibre as it is a GUI application, so
Homebrew-cask is the alternative. I found that generating an ebook
required adding the Calibre CLI to my PATH, as referenced in
https://github.com/GitbookIO/gitbook/issues/333#issuecomment-64134770.