### PR TITLE
Alt create store comment

### DIFF
--- a/manuscript/07_from_notes_to_kanban.md
+++ b/manuscript/07_from_notes_to_kanban.md
@@ -109,7 +109,7 @@ class LaneStore {
 
     this.setState({
       lanes: lanes.concat({
-        name: name,
+        name: name
       })
     });
   }

--- a/manuscript/07_from_notes_to_kanban.md
+++ b/manuscript/07_from_notes_to_kanban.md
@@ -119,6 +119,7 @@ export default alt.createStore(LaneStore, 'LaneStore');
 ```
 
 The idea is the same as before with lanes. We are also going to need that `Lanes` container.
+The idea is the same as before with notes. We are also going to need that `Lanes` container.
 
 **app/components/Lanes.jsx**
 

--- a/manuscript/07_from_notes_to_kanban.md
+++ b/manuscript/07_from_notes_to_kanban.md
@@ -118,7 +118,8 @@ class LaneStore {
 export default alt.createStore(LaneStore, 'LaneStore');
 ```
 
-The idea is the same as before with lanes. We are also going to need that `Lanes` container.
+The second parameter in `createStore` is a string that is used as a unique identifier for serializing/deserializing your store. The name of the store comes from the class name but on production due to heavy minification it is a good idea to provide your own name to avoid collisions.
+
 The idea is the same as before with notes. We are also going to need that `Lanes` container.
 
 **app/components/Lanes.jsx**


### PR DESCRIPTION
In fact there are two commits here, one is about a typo. 

And the other one adds an explanation for the string parameter in `createStore`. I think it's better to either remove it or to explain why it's there.