### PR TITLE
Update path to bundle.js in 02_getting_started.md index.html file.

### DIFF
--- a/manuscript/02_getting_started.md
+++ b/manuscript/02_getting_started.md
@@ -125,7 +125,7 @@ In order to actually use our bundle, we'll need to define the last missing bit, 
     <meta charset="UTF-8"/>
   </head>
   <body>
-    <script src="bundle.js"></script>
+    <script src="build/bundle.js"></script>
   </body>
 </html>
 ```


### PR DESCRIPTION
When loading the first webpack generated `bundle.js` file in the 02_getting_started.md file it 404'd until I updated the script path in body to match the path laid out for `bundle.js` in [Directory Structure](https://github.com/survivejs/webpack_react/blob/master/manuscript/02_getting_started.md#directory-structure) section. 