### PR TITLE
Update build_all.sh to include NPM dependencies

### DIFF
--- a/project_source/build_all.sh
+++ b/project_source/build_all.sh
@@ -4,6 +4,8 @@ for d in */; do
     APP_DIR="$d/kanban_app"
     if [ -d "$APP_DIR" ]; then
         pushd "$APP_DIR"
+        echo "Installing dependencies for $d"
+        npm install
         echo "Building $d"
         npm run build
         popd


### PR DESCRIPTION
It defeats the purpose if an user needs to go to each project to install the dependencies. Useful is someone wants to try the `site` repo.