### PR TITLE
Correct usage of "e.g." to "e.g.,". It is usually placed in parenthes…

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Feedback is welcome. You can provide it through [the issue tracker](https://gith
 
 If you want a rough pdf version, you can generate one through Calibre. It won't look as pretty as [the official version](https://leanpub.com/survivejs_webpack) and will be missing some content. That said it's better than nothing if you cannot afford the full monty for a reason or another. I'm not blaming you. :)
 
-Make sure you have Calibre installed before trying the generation script. You can get it from [Calibre site](http://calibre-ebook.com/download) or alternatively you can use the package manager of your operating system (Homebrew-cask for Mac, `sudo apt-get install calibre calibre-bin` for Ubuntu). If you use Homebrew-cask, you may need to add the Calibre CLI to your PATH (e.g. `export PATH=$PATH://opt/homebrew-cask/Caskroom/calibre/2.31.0/calibre.app/Contents/MacOS`).
+Make sure you have Calibre installed before trying the generation script. You can get it from [Calibre site](http://calibre-ebook.com/download) or alternatively you can use the package manager of your operating system (Homebrew-cask for Mac, `sudo apt-get install calibre calibre-bin` for Ubuntu). If you use Homebrew-cask, you may need to add the Calibre CLI to your PATH (e.g., `export PATH=$PATH://opt/homebrew-cask/Caskroom/calibre/2.31.0/calibre.app/Contents/MacOS`).
 
 To generate a pdf version of the book, hit `npm install` and `npm start`. After that you should have `./book.pdf`.
 

--- a/manuscript/01_webpack_compared.md
+++ b/manuscript/01_webpack_compared.md
@@ -48,9 +48,9 @@ T> Note that [grunt-webpack](https://www.npmjs.com/package/grunt-webpack) plugin
 
 ![Gulp](images/gulp.png)
 
-Gulp takes a different approach. Instead of relying on configuration per plugin you deal with actual code. Gulp builds on top of the tried and true concept of piping. If you are familiar with Unix, it's the same idea here. You simply have sources, filters and sinks.
+Gulp takes a different approach. Instead of relying on configuration per plugin, you deal with actual code. Gulp builds on top of the tried and true concept of piping. If you are familiar with Unix, it's the same idea here. You simply have sources, filters, and sinks.
 
-Sources match files. Filters perform operations on those (e.g. convert to JavaScript). Finally, it gets passed to sinks (your build directory etc.). Here's a sample `Gulpfile` to give you a better idea of the approach taken from the project README. It has been abbreviated a bit:
+Sources match files. Filters perform operations on those (e.g., convert to JavaScript). Finally, it gets passed to sinks (your build directory etc.). Here's a sample `Gulpfile` to give you a better idea of the approach taken from the project README. It has been abbreviated a bit:
 
 ```javascript
 var gulp = require('gulp');
@@ -104,7 +104,7 @@ Dealing with JavaScript modules has always been a bit of a problem. The language
 
 In practice, it can be useful just to use CommonJS, the Node.js format, and let the tooling deal with the rest. The advantage is that you can often hook into npm and avoid reinventing the wheel.
 
-[Browserify](http://browserify.org/) solves this problem. It provides a way to bundle CommonJS modules together. You can hook it up with Gulp. There are smaller transformation tools that allow you to move beyond the basic usage. E.g. [watchify](https://www.npmjs.com/package/watchify) provides a file watcher that creates bundles for you during development. This will save some effort and no doubt is a good solution up to a point.
+[Browserify](http://browserify.org/) solves this problem. It provides a way to bundle CommonJS modules together. You can hook it up with Gulp. There are smaller transformation tools that allow you to move beyond the basic usage. For example, [watchify](https://www.npmjs.com/package/watchify) provides a file watcher that creates bundles for you during development. This will save some effort and no doubt is a good solution up to a point.
 
 The Browserify ecosystem is composed of a lot of small modules. This way they remind of the Unix philosophy. It is a little easier to adopt than Webpack and in fact, it is a good alternative to it.
 

--- a/manuscript/02_developing_with_webpack.md
+++ b/manuscript/02_developing_with_webpack.md
@@ -171,7 +171,7 @@ Hit `npm start` and surf to **localhost:8080**. You should see something familia
 
 Or we can run the application from **localhost:8080/webpack-dev-server/bundle** instead of root. It provides an iframe showing a status bar. It indicates the status of the rebundling process.
 
-T> If you want to use some other port than `8080`, you can pass `port` parameter (e.g. `port: 4000`) to *devServer*.
+T> If you want to use some other port than `8080`, you can pass `port` parameter (e.g., `port: 4000`) to *devServer*.
 
 In addition to **webpack.config.js** it is possible to set *webpack-dev-server* configuration through cli. There is also an entire [Node.js API](https://webpack.github.io/docs/webpack-dev-server.html#api) available in case you want most control over it.
 

--- a/manuscript/04_implementing_notes.md
+++ b/manuscript/04_implementing_notes.md
@@ -744,7 +744,7 @@ In addition, React provides the following lifecycle hooks:
 * `shouldComponentUpdate(object nextProps, object nextState)` allows you to optimize the rendering. If you check the props and state and see that there's no need to update, return `false`.
 * `componentWillUpdate(object nextProps, object nextState)` gets triggered after `shouldComponentUpdate` and before `render()`. It is not possible to use `setState` here, but you can set class properties for instance.
 * `componentDidUpdate` is triggered after rendering. You can modify the DOM here. This can be useful for adapting other code to work with React.
-* `componentWillUnmount` is triggered just before a component is unmounted from the DOM. This is the ideal place to perform cleanup (e.g. remove running timers, custom DOM elements and so on).
+* `componentWillUnmount` is triggered just before a component is unmounted from the DOM. This is the ideal place to perform cleanup (e.g., remove running timers, custom DOM elements and so on).
 
 ## React Component Conventions
 

--- a/manuscript/05_react_and_flux.md
+++ b/manuscript/05_react_and_flux.md
@@ -217,7 +217,7 @@ class NoteStore {
 export default alt.createStore(NoteStore, 'NoteStore');
 ```
 
-It would be possible to operate directly on data. E.g. a oneliner such as `this.notes.splice(targetId, 1)` would work for `delete`. It is recommended that you use `setState` with Alt to keep things clean and easy to understand.
+It would be possible to operate directly on data. For example a oneliner such as `this.notes.splice(targetId, 1)` would work for `delete`. It is recommended that you use `setState` with Alt to keep things clean and easy to understand.
 
 We have almost integrated Flux to our application now. We have a set of Actions that provide an API for manipulating `Notes` data. We also have a Store for actual data manipulation. We are missing one final bit - integration with our View. It will have to listen to the Store and be able to trigger Actions to complete the cycle.
 

--- a/manuscript/06_from_notes_to_kanban.md
+++ b/manuscript/06_from_notes_to_kanban.md
@@ -358,7 +358,7 @@ After these changes we have set up a system that can maintain relations between 
 
 ### Alternative Designs
 
-There are a couple of alternatives to the current design. The data structure, it uses is convenient. This is true particularly for lane related operations (e.g. moving notes). `Lanes` know which `Notes` they contain.
+There are a couple of alternatives to the current design. The data structure, it uses is convenient. This is true particularly for lane related operations (e.g., moving notes). `Lanes` know which `Notes` they contain.
 
 This will be important as we implement drag and drop. Incidentally the current structure would work nicely with a back-end. The current structures would map neatly to a RESTful API. We would have resources for both `Lanes` and `Notes`. Each action would then operate through these directly using standard CRUD interface.
 
@@ -611,7 +611,7 @@ body {
 ...
 ```
 
-As this is a small project we can leave the CSS in a single file like this. In case it starts growing, consider separating it to multiple. One way to do this is to extract CSS per component and then refer to it there (e.g. `require('./lane.css')` at `Lane.jsx`).
+As this is a small project we can leave the CSS in a single file like this. In case it starts growing, consider separating it to multiple. One way to do this is to extract CSS per component and then refer to it there (e.g., `require('./lane.css')` at `Lane.jsx`).
 
 Besides keeping things nice and tidy Webpack's lazy loading machinery can pick this up. As a result, the initial CSS your user has to load will be smaller. I go into further detail later as I discuss styling.
 

--- a/manuscript/10_authoring_libraries.md
+++ b/manuscript/10_authoring_libraries.md
@@ -136,7 +136,7 @@ An alternative way to consume a library is to point at it directly at `package.j
 
 ## Respect the SemVer
 
-Even though it is simple to publish new versions out there, it is important to respect the SemVer. Roughly it states that you should not break backwards compatibility given certain rules are met. E.g. if your current version is `0.1.4` and you do a breaking change, you should bump to `0.2.0` and document the changes. You can understand SemVer much better by studying [the online tool](http://semver.npmjs.com/) and how it behaves.
+Even though it is simple to publish new versions out there, it is important to respect the SemVer. Roughly it states that you should not break backwards compatibility given certain rules are met. For example, if your current version is `0.1.4` and you do a breaking change, you should bump to `0.2.0` and document the changes. You can understand SemVer much better by studying [the online tool](http://semver.npmjs.com/) and how it behaves.
 
 ## Library Formats
 

--- a/manuscript/11_styling_react.md
+++ b/manuscript/11_styling_react.md
@@ -1,12 +1,12 @@
 # Styling React
 
-Traditionally web pages have been split up in markup (e.g. HTML), styling (e.g. CSS) and logic (e.g. JavaScript). Even though this sounds simple in practice, there are overlaps. You might trigger CSS animations through JavaScript. As seen earlier React provides a component oriented way of development. This in turn allows us to question some of our earlier beliefs.
+Traditionally web pages have been split up in markup (HTML), styling (CSS) and logic (JavaScript). Even though this sounds simple in practice, there are overlaps. You might trigger CSS animations through JavaScript. As seen earlier React provides a component oriented way of development. This in turn allows us to question some of our earlier beliefs.
 
 With React styling is still in bit of a flux and we're still figuring out the best ways to deal with it. Some patterns have begun to emerge, however. Perhaps some of the ideas will stick. It is hard to give any specific recommendations as it is dependent on the case and the way you like to work.
 
 ## Old School Styling
 
-The old school approach to styling was to sprinkle some ids and classes around, set up rules and hope for the best. Although this can work up to an extent it gets more complicated as development goes on. By default, everything is global in CSS. Furthermore nesting definitions (e.g. `.main .sidebar .button`) creates implicit logic to your styling.
+The old school approach to styling was to sprinkle some ids and classes around, set up rules and hope for the best. Although this can work up to an extent it gets more complicated as development goes on. By default, everything is global in CSS. Furthermore nesting definitions (e.g., `.main .sidebar .button`) creates implicit logic to your styling.
 
 ### Webpack Configuration for Vanilla CSS
 
@@ -61,7 +61,7 @@ The primary benefit of adopting a methodology is that it brings certain structur
 
 On the downside once you adopt one you are pretty much stuck with that on your project. But if you are willing to commit, there are benefits to gain.
 
-The methodologies also bring their own quirks (e.g. complex naming schemes). This may make certain things more complicated than they have to be. They don't necessarily solve any of the bigger underlying issues. They rather provide patches around them.
+The methodologies also bring their own quirks (e.g., complex naming schemes). This may make certain things more complicated than they have to be. They don't necessarily solve any of the bigger underlying issues. They rather provide patches around them.
 
 There are various approaches that go deeper and solve some of these fundamental problems. That said, it's not an either-or proposition. You may adopt a methodology even if you use some preprocessor.
 
@@ -118,7 +118,7 @@ Check out the loader for more advanced usage.
 
 ### Pros and Cons
 
-Compared to vanilla CSS, preprocessors bring a lot to the table. They deal with certain annoyances (e.g. autoprefixing) and provide useful features. Particularly cssnext and postcss seem future proof alternatives to me. That said, I can see value in other preprocessors as they are established and well understood projects.
+Compared to vanilla CSS, preprocessors bring a lot to the table. They deal with certain annoyances (e.g., autoprefixing) and provide useful features. Particularly cssnext and postcss seem future proof alternatives to me. That said, I can see value in other preprocessors as they are established and well understood projects.
 
 In our project we could benefit from cssnext even if we didn't make any changes to our CSS. Thanks to autoprefixing rounded corners of our lanes would look good even in legacy browsers. In addition, we could parameterize styling thanks to variables.
 
@@ -169,7 +169,7 @@ How about things like media queries? This naive approach won't quite cut it. For
 
 According to Michele Bertoli basic features of these libraries are
 
-* Autoprefixing - E.g. for `border`, `animation`, `flex`, ...
+* Autoprefixing - for `border`, `animation`, `flex`, ...
 * Pseudo classes - `:hover`, `:active`, ...
 * Media queries - `@media (max-width: 200px)`, ...
 * Styles as Object Literals - See example above
@@ -179,7 +179,7 @@ I will cover some of the available libraries to give you a better idea how they 
 
 ### Radium
 
-[Radium](http://projects.formidablelabs.com/radium/) has certain valuable ideas that are worth highlighting. Most importantly it provides abstractions required to deal with media queries and pseudo classes (e.g. `:hover`).
+[Radium](http://projects.formidablelabs.com/radium/) has certain valuable ideas that are worth highlighting. Most importantly it provides abstractions required to deal with media queries and pseudo classes (e.g., `:hover`).
 
 It expands the basic syntax as follows:
 
@@ -245,7 +245,7 @@ const styles = StyleSheet.create({
 <button styles={[styles.button, styles.primary]}>Confirm</button>
 ```
 
-As you can see we can use individual fragments to get the same effect as Radium modifiers. Also media queries are supported. React Style expects that you manipulate browser states (e.g. `:hover` and such) through JavaScript. Also CSS animations won't work. Instead, it's preferred to use some other solution for that.
+As you can see we can use individual fragments to get the same effect as Radium modifiers. Also media queries are supported. React Style expects that you manipulate browser states (e.g., `:hover`) through JavaScript. Also CSS animations won't work. Instead, it's preferred to use some other solution for that.
 
 Interestingly there is a [React Style plugin for Webpack](https://github.com/js-next/react-style-webpack-plugin). It can extract CSS declarations into a separate bundle. Now we are closer to the world we're used to, but without cascades. We also have our style declarations on component level.
 
@@ -303,7 +303,7 @@ class ConfirmButton extends React.Component {
 }
 ```
 
-Unlike React Style, the approach supports browser states (e.g. `:hover` etc.). Unfortunately, it relies on its own custom tooling to generate React code and CSS it needs to work. As of yet, there's no Webpack loader available.
+Unlike React Style, the approach supports browser states (e.g., `:hover`). Unfortunately, it relies on its own custom tooling to generate React code and CSS it needs to work. As of yet, there's no Webpack loader available.
 
 ### jsxstyle
 


### PR DESCRIPTION
…es and serves a single example of the previous clause in the sentence. "For example," should be used to start a sentence instead of "e.g.,".