### PR TITLE
fixed ch11 linting css example

### DIFF
--- a/manuscript/11_linting_in_webpack.md
+++ b/manuscript/11_linting_in_webpack.md
@@ -352,7 +352,7 @@ var common = {
   postcss: function () {
     return [stylelint({
       rules: {
-        'color-hex-case': 2
+        'color-hex-case': 'lower'
       }
     })];
   },


### PR DESCRIPTION
origin state created this warning:
WARNING in ./~/css-loader!./~/postcss-loader!./app/main.css
stylelint: Expected option value for rule "color-hex-case"

changing to lower and using upper for color-hex creates this warning (intended with the example):
WARNING in ./~/css-loader!./~/postcss-loader!./app/main.css
stylelint: /Users/mitch/Learn/surviveJS/kanban_app/app/main.css:2:3: Expected "#F0F0F0" to be "#f0f0f0" (color-hex-case)

https://github.com/stylelint/stylelint/tree/master/src/rules/color-hex-case