### PR TITLE
classes and modules for ES6

### DIFF
--- a/manuscript/14_language_features.md
+++ b/manuscript/14_language_features.md
@@ -135,26 +135,31 @@ As stated above, the ES6 modules allow `export` and `import` single and multiple
 
 To export and import a single class you can use `export default class` to export an anonymous class and call it whatever you want at import time:
 
+**Note.jsx**
 ```javascript
-//------ Note.jsx ------
 export default class extends React.Component { ... };
+```
 
-//------ Notes.jsx ------
+**Notes.jsx**
+```javascript
 import Note from './Note.jsx';
 ...
 ```
 
 Or use `export class className` to export several named classes from a single module:
 
+**Components.jsx**
 ```javascript
-//------ Components.jsx ------
 export class Note extends React.Component { ... };
 
 export class Notes extends React.Component { ... };
+```
 
-//------ App.jsx ------
+**App.jsx**
+```javascript
 import Notes from './Components.jsx';
 import Note from './Components.jsx';
+
 ...
 ```
 

--- a/manuscript/14_language_features.md
+++ b/manuscript/14_language_features.md
@@ -130,6 +130,36 @@ export default class App extends React.Component {
 
 Perhaps the biggest advantage of the class based approach is the fact that it cuts down some complexity, especially when it comes to React lifecycle hooks. It is important to note that class methods won't get by default, though! This is why the book relies on an experimental feature known as property initializers.
 
+### Classes and Modules
+As stated above, the ES6 modules allow `export` and `import` single and multiple objects, functions, or even classes. In the latter, you can use `export default class` to export an anonymous class or export multiple classes from the same module using `export class className`.
+
+To export and import a single class you can use `export default class` to export an anonymous class and call it whatever you want at import time:
+
+```javascript
+//------ Note.jsx ------
+export default class extends React.Component { ... };
+
+//------ Notes.jsx ------
+import Note from './Note.jsx';
+...
+```
+
+Or use `export class className` to export several named classes from a single module:
+
+```javascript
+//------ Components.jsx ------
+export class Note extends React.Component { ... };
+
+export class Notes extends React.Component { ... };
+
+//------ App.jsx ------
+import Notes from './Components.jsx';
+import Note from './Components.jsx';
+...
+```
+
+Nevertheless is always recommended keep your classes separated in different modules.
+
 ## Property Initializers
 
 ES6 classes won't bind their methods by default. This can be problematic sometimes, as you still may want to be able to access the instance properties. Without property initializers we might write something like this:


### PR DESCRIPTION
Add a section to explain what are the differences and how the **ES6 classes** works when using `export default class` and `export class` with **ES6 modules**.