### PR TITLE
Missing last semicolon for addNote() declaration

### DIFF
--- a/manuscript/04_implementing_notes.md
+++ b/manuscript/04_implementing_notes.md
@@ -239,7 +239,7 @@ leanpub-start-insert
         task: 'New task'
       }])
     });
-  }
+  };
 leanpub-end-insert
 }
 ```


### PR DESCRIPTION
Webpack will not build, complain, and correctly point out the syntax error.