### PR TITLE
Skipped deletion

### DIFF
--- a/manuscript/05_react_and_flux.md
+++ b/manuscript/05_react_and_flux.md
@@ -523,6 +523,9 @@ leanpub-start-delete
   }
 leanpub-end-delete
   render() {
+    leanpub-start-delete
+      const notes = this.state.notes;
+    leanpub-end-delete
     return (
       <div>
         <button className="add-note" onClick={this.addNote}>+</button>


### PR DESCRIPTION
At this point however, the deletion may be implied with the change to AltContainer. Not sure if you want to include it. But the app will error saying 'this.state is null' in browser console.