### PR TITLE
Fix bracket consistency between sections

### DIFF
--- a/manuscript/02_developing_with_webpack.md
+++ b/manuscript/02_developing_with_webpack.md
@@ -445,8 +445,8 @@ Now that we have the loaders we need, we'll need to make sure Webpack is aware o
 
 const common = {
   ...
+  },
 leanpub-start-insert
-  ],
   module: {
     loaders: [
       {


### PR DESCRIPTION
There isn't a need to insert a '],' there, but I think it was supposed to be a '},' to help guide the reader where to put the code.