### PR TITLE
Editable, Note insert/delete swapped

### DIFF
--- a/manuscript/06_from_notes_to_kanban.md
+++ b/manuscript/06_from_notes_to_kanban.md
@@ -551,10 +551,10 @@ We are still missing some basic functionality, such as editing and removing lane
 import React from 'react';
 
 leanpub-start-delete
-export default class Editable extends React.Component {
+export default class Note extends React.Component {
 leanpub-end-delete
 leanpub-start-insert
-export default class Note extends React.Component {
+export default class Editable extends React.Component {
 leanpub-end-insert
 leanpub-start-delete
   constructor(props) {


### PR DESCRIPTION
we're starting to work on Editable.jsx (copied from Note.jsx).
our first step should be replacing "class Note" with "class
Editable" not the other way around.