### PR TITLE
Fix jshint sample webpack config to support JSX

### DIFF
--- a/manuscript/11_linting_in_webpack.md
+++ b/manuscript/11_linting_in_webpack.md
@@ -30,7 +30,7 @@ var common = {
   module: {
     preLoaders: [
       {
-        test: /\.js?$/,
+        test: /\.jsx?$/,
         loaders: ['jshint'],
         // define an include so we check just the files we need
         include: PATHS.app


### PR DESCRIPTION
There was an 'x' missing from the jshint example webpack config, in the filename test. This changes adds it.