### PR TITLE
Removing unreachable if condition

### DIFF
--- a/manuscript/07_implementing_dnd.md
+++ b/manuscript/07_implementing_dnd.md
@@ -668,12 +668,17 @@ leanpub-start-insert
 leanpub-end-insert
 
       if(lane.id === laneId) {
+leanpub-start-delete
         if(lane.notes.includes(noteId)) {
           console.warn('Already attached note to lane', lanes);
         }
         else {
           lane.notes.push(noteId);
         }
+leanpub-end-delete
+leanpub-start-insert
+        lane.notes.push(noteId);
+leanpub-end-insert
       }
 
       return lane;

--- a/project_source/07_implementing_dnd/kanban_app/app/stores/LaneStore.js
+++ b/project_source/07_implementing_dnd/kanban_app/app/stores/LaneStore.js
@@ -45,12 +45,7 @@ class LaneStore {
       }
 
       if(lane.id === laneId) {
-        if(lane.notes.includes(noteId)) {
-          console.warn('Already attached note to lane', lanes);
-        }
-        else {
-          lane.notes.push(noteId);
-        }
+        lane.notes.push(noteId);
       }
 
       return lane;


### PR DESCRIPTION
After adding code to filter out the note, the second `if(lane.notes.includes(noteId))` statement doesn't seem necessary.