### PR TITLE
Removed redundant spread operator

### DIFF
--- a/manuscript/implementing_kanban/01_react_and_flux.md
+++ b/manuscript/implementing_kanban/01_react_and_flux.md
@@ -309,9 +309,9 @@ function connect(state = () => {}, actions = {}, target) {
       const composedStores = composeStores(stores);
 
       return React.createElement(target,
-        {...Object.assign(
+        Object.assign(
           {}, this.props, state(composedStores), actions
-        )}
+        )
       );
     }
     handleChange = () => {


### PR DESCRIPTION
Object.assign returns an object anyways. Spread operator there adds confusion.